### PR TITLE
perf: avoid overuse of interfaces

### DIFF
--- a/computed.go
+++ b/computed.go
@@ -86,15 +86,13 @@ func updateComputed(rs *ReactiveSystem, c any) bool {
 // @param computed - The computed subscriber to update.
 // @param flags - The current flag set for this subscriber.
 func processComputedUpdate(rs *ReactiveSystem, computed computedAny, flags subscriberFlags) {
-	if flags&fDirty != 0 || func() bool {
+	dirty := flags&fDirty != 0
+	if !dirty {
 		sub := computed.sub()
-		isDirty := rs.checkDirty(sub.deps)
-		if isDirty {
-			return true
-		}
+		dirty = rs.checkDirty(sub.deps)
 		sub.flags = flags & ^fPendingComputed
-		return false
-	}() {
+	}
+	if dirty {
 		if updateComputed(rs, computed) {
 			subs := computed.dep().subs
 			if subs != nil {

--- a/effects.go
+++ b/effects.go
@@ -37,7 +37,8 @@ func (rs *ReactiveSystem) runEffect(e *EffectRunner) {
 	rs.activeSub = prevSub
 }
 
-func (rs *ReactiveSystem) notifyEffect(e *EffectRunner) bool {
+func (rs *ReactiveSystem) notifyEffect(sub subscriber) bool {
+	e := mustEffect(sub)
 	flags := e.flags()
 	if flags&fEffectScope != 0 {
 		flags := e.flags()

--- a/effects.go
+++ b/effects.go
@@ -136,22 +136,13 @@ func (rs *ReactiveSystem) processPendingInnerEffects(sub subscriber, flags subsc
 // notifications may be triggered until fully handled.
 func (rs *ReactiveSystem) processEffectNotifications() {
 	for rs.queuedEffects != nil {
-		e := rs.queuedEffects
-		depsTail := e.depsTail()
-		queueNext := depsTail.nextDep
-		if queueNext != nil {
-			depsTail.nextDep = nil
-			effect, ok := queueNext.sub.(*EffectRunner)
-			if !ok {
-				panic("not an effect")
-			}
-			rs.queuedEffects = effect
-		} else {
-			rs.queuedEffects = nil
+		effect := rs.queuedEffects.target
+		rs.queuedEffects = rs.queuedEffects.linked
+		if rs.queuedEffects == nil {
 			rs.queuedEffectsTail = nil
 		}
-		if !rs.notifyEffect(e) {
-			e.setFlags(e.flags() & ^fNotified)
+		if !rs.notifyEffect(effect) {
+			effect.setFlags(effect.flags() & ^fNotified)
 		}
 	}
 }

--- a/signals.go
+++ b/signals.go
@@ -6,6 +6,10 @@ type WriteableSignal[T comparable] struct {
 	value T
 }
 
+func (s *WriteableSignal[T]) dep() *baseDependency {
+	return &s.baseDependency
+}
+
 func (s *WriteableSignal[T]) isSignalAware() {}
 
 func (s *WriteableSignal[T]) Value() T {
@@ -20,7 +24,7 @@ func (s *WriteableSignal[T]) SetValue(v T) {
 		return
 	}
 	s.value = v
-	subs := s._subs
+	subs := s.baseDependency.subs
 	if subs != nil {
 		s.rs.propagate(subs)
 		if s.rs.batchDepth == 0 {
@@ -31,8 +35,9 @@ func (s *WriteableSignal[T]) SetValue(v T) {
 
 func Signal[T comparable](rs *ReactiveSystem, initialValue T) *WriteableSignal[T] {
 	s := &WriteableSignal[T]{
-		rs:    rs,
-		value: initialValue,
+		rs:             rs,
+		value:          initialValue,
+		baseDependency: baseDependency{},
 	}
 	return s
 }

--- a/types.go
+++ b/types.go
@@ -24,66 +24,18 @@ type link struct {
 }
 
 type subscriber interface {
-	flags() subscriberFlags
-	setFlags(subscriberFlags)
-	deps() *link
-	setDeps(*link)
-	depsTail() *link
-	setDepsTail(*link)
-}
-
-type baseSubscriber struct {
-	_flags           subscriberFlags
-	_deps, _depsTail *link
-}
-
-func (s *baseSubscriber) flags() subscriberFlags {
-	return s._flags
-}
-func (s *baseSubscriber) setFlags(flags subscriberFlags) {
-	s._flags = flags
-}
-func (s *baseSubscriber) deps() *link {
-	return s._deps
-}
-func (s *baseSubscriber) setDeps(deps *link) {
-	s._deps = deps
-}
-func (s *baseSubscriber) depsTail() *link {
-	return s._depsTail
-}
-func (s *baseSubscriber) setDepsTail(depsTail *link) {
-	s._depsTail = depsTail
+	sub() *baseSubscriber
 }
 
 type dependency interface {
-	subs() *link
-	setSubs(*link)
-	subsTail() *link
-	setSubsTail(*link)
+	dep() *baseDependency
+}
+
+type baseSubscriber struct {
+	flags          subscriberFlags
+	deps, depsTail *link
 }
 
 type baseDependency struct {
-	_subs, _subsTail *link
-}
-
-func (d *baseDependency) subs() *link {
-	return d._subs
-}
-
-func (d *baseDependency) setSubs(subs *link) {
-	d._subs = subs
-}
-
-func (d *baseDependency) subsTail() *link {
-	return d._subsTail
-}
-
-func (d *baseDependency) setSubsTail(subsTail *link) {
-	d._subsTail = subsTail
-}
-
-type dependencyAndSubscriber interface {
-	dependency
-	subscriber
+	subs, subsTail *link
 }

--- a/types.go
+++ b/types.go
@@ -16,13 +16,10 @@ const (
 )
 
 type link struct {
-	dep dependency
-	sub subscriber
-	// reused to link the previous stack in updateDirtyFlags
-	// reused to link the previous stack in propagate
+	dep     dependency
+	sub     subscriber
 	prevSub *link
 	nextSub *link
-	// reused to link the notify effect in queueEffects
 	nextDep *link
 }
 


### PR DESCRIPTION
This is a easy win, as performance can be significantly improved by having fewer interface usages.

Before:

```
+------------------------+-------------+-------------+-------------+--------------+--------------+
| BENCHMARK              |         AVG |         MIN |         P75 |          P99 |          MAX |
+------------------------+-------------+-------------+-------------+--------------+--------------+
| propagate: 1 * 1       |       597ns |       291ns |       334ns |        875ns |     26.083µs |
| propagate: 1 * 10      |     1.857µs |       1.5µs |     2.083µs |      2.292µs |      2.833µs |
| propagate: 1 * 100     |    11.659µs |    11.334µs |    11.583µs |     13.916µs |         14µs |
| propagate: 1 * 1000    |    92.858µs |      87.5µs |    91.584µs |    106.375µs |    224.375µs |
| propagate: 10 * 1      |     1.652µs |     1.542µs |     1.625µs |      2.291µs |      2.916µs |
| propagate: 10 * 10     |    10.069µs |     9.792µs |        10µs |      10.75µs |     21.625µs |
| propagate: 10 * 100    |    75.512µs |    65.584µs |    78.958µs |     80.625µs |     80.666µs |
| propagate: 10 * 1000   |   536.325µs |   527.625µs |   530.208µs |    611.875µs |    821.292µs |
| propagate: 100 * 1     |     9.986µs |     9.416µs |    10.042µs |      12.75µs |         17µs |
| propagate: 100 * 10    |    67.687µs |    66.709µs |    67.792µs |     70.166µs |     81.292µs |
| propagate: 100 * 100   |   569.186µs |     564.5µs |    570.25µs |    580.167µs |    581.917µs |
| propagate: 100 * 1000  |  6.164137ms |    5.3745ms |  5.582958ms |  19.104042ms |  29.470375ms |
| propagate: 1000 * 1    |   100.072µs |    93.333µs |   100.833µs |    120.542µs |    152.416µs |
| propagate: 1000 * 10   |   671.385µs |   658.958µs |   672.667µs |    709.792µs |    721.709µs |
| propagate: 1000 * 100  |  6.216569ms |  5.903333ms |  6.236542ms |   7.310417ms |   7.365375ms |
| propagate: 1000 * 1000 | 75.293745ms | 56.491541ms | 58.114542ms | 578.191709ms | 636.755834ms |
+------------------------+-------------+-------------+-------------+--------------+--------------+
```

After:

```
+------------------------+-------------+-------------+-------------+-------------+-------------+
| BENCHMARK              |         AVG |         MIN |         P75 |         P99 |         MAX |
+------------------------+-------------+-------------+-------------+-------------+-------------+
| propagate: 1 * 1       |       329ns |        84ns |       125ns |     3.542µs |    16.166µs |
| propagate: 1 * 10      |       674ns |       500ns |       750ns |         1µs |     1.542µs |
| propagate: 1 * 100     |     4.356µs |     3.917µs |     4.292µs |       4.5µs |    17.042µs |
| propagate: 1 * 1000    |    46.728µs |    43.709µs |    46.875µs |    61.459µs |     65.25µs |
| propagate: 10 * 1      |     1.007µs |       833ns |       958ns |     3.042µs |      6.25µs |
| propagate: 10 * 10     |     5.214µs |     5.042µs |     5.208µs |     5.834µs |       7.5µs |
| propagate: 10 * 100    |    49.637µs |    47.125µs |    50.166µs |     55.75µs |    89.542µs |
| propagate: 10 * 1000   |   452.977µs |   443.416µs |    449.75µs |   497.708µs |   704.459µs |
| propagate: 100 * 1     |     9.107µs |     8.542µs |     9.042µs |     13.75µs |    18.541µs |
| propagate: 100 * 10    |     59.72µs |    57.375µs |    60.333µs |    69.792µs |    69.958µs |
| propagate: 100 * 100   |   491.987µs |   478.833µs |    496.25µs |     564.5µs |   571.917µs |
| propagate: 100 * 1000  |  5.355754ms |  4.595875ms |   4.77475ms |  27.51375ms | 32.936375ms |
| propagate: 1000 * 1    |      83.7µs |    77.291µs |    81.417µs |   139.292µs |   169.583µs |
| propagate: 1000 * 10   |   585.577µs |   563.916µs |   587.625µs |   710.791µs |    774.25µs |
| propagate: 1000 * 100  |  5.199786ms |  4.929667ms |  5.272666ms |  6.085959ms |  7.464666ms |
| propagate: 1000 * 1000 | 49.701124ms | 47.613416ms | 48.836709ms | 66.319375ms | 70.751417ms |
+------------------------+-------------+-------------+-------------+-------------+-------------+
```