### PR TITLE
2x Performance Boost

### DIFF
--- a/computed.go
+++ b/computed.go
@@ -1,8 +1,7 @@
 package alien
 
 type ReadonlySignal[T comparable] struct {
-	baseSubscriber
-	baseDependency
+	signal
 
 	rs     *ReactiveSystem
 	value  T
@@ -12,59 +11,55 @@ type ReadonlySignal[T comparable] struct {
 func (s *ReadonlySignal[T]) isSignalAware() {}
 
 func (s *ReadonlySignal[T]) Value() T {
-	flags := s._flags
+	flags := s.flags
+	signal := &s.signal
 	if flags&(fDirty|fPendingComputed) != 0 {
-		processComputedUpdate(s.rs, s, flags)
+		processComputedUpdate(s.rs, signal, flags)
 	}
 	if s.rs.activeSub != nil {
-		s.rs.link(s, s.rs.activeSub)
+		s.rs.link(signal, s.rs.activeSub)
 	} else if s.rs.activeScope != nil {
-		s.rs.link(s, s.rs.activeScope)
+		s.rs.link(signal, s.rs.activeScope)
 	}
 
 	return s.value
 }
 
-func (s *ReadonlySignal[T]) cas() (wasDifferent bool) {
+func (s *ReadonlySignal[T]) cas() bool {
 	oldValue := s.value
 	newValue := s.getter(oldValue)
-	wasDifferent = oldValue != newValue
 	s.value = newValue
-	return wasDifferent
+	return oldValue != newValue
 }
 
 func Computed[T comparable](rs *ReactiveSystem, getter func(oldValue T) T) *ReadonlySignal[T] {
 	c := &ReadonlySignal[T]{
 		rs:     rs,
 		getter: getter,
-		baseSubscriber: baseSubscriber{
-			_flags: fComputed | fDirty,
+		signal: signal{
+			flags: fComputed | fDirty,
 		},
 	}
+	signal := &c.signal
+	signal.ref = c
 	return c
 }
 
 type computedAny interface {
-	dependencyAndSubscriber
 	cas() (wasDifferent bool)
 }
 
-func updateComputed(rs *ReactiveSystem, c any) bool {
-	computed, ok := c.(computedAny)
-	if !ok {
-		panic("not a computedAny")
-	}
-
+func updateComputed(rs *ReactiveSystem, signal *signal) bool {
 	prevSub := rs.activeSub
-	rs.activeSub = computed
-	rs.startTracking(computed)
+	rs.activeSub = signal
+	rs.startTracking(signal)
 
 	defer func() {
 		rs.activeSub = prevSub
-		rs.endTracking(computed)
+		rs.endTracking(signal)
 	}()
 
-	return computed.cas()
+	return signal.ref.(computedAny).cas()
 }
 
 // Updates the computed subscriber if necessary before its value is accessed.
@@ -75,17 +70,15 @@ func updateComputed(rs *ReactiveSystem, c any) bool {
 //
 // @param computed - The computed subscriber to update.
 // @param flags - The current flag set for this subscriber.
-func processComputedUpdate(rs *ReactiveSystem, computed computedAny, flags subscriberFlags) {
-	if flags&fDirty != 0 || func() bool {
-		isDirty := rs.checkDirty(computed.deps())
-		if isDirty {
-			return true
-		}
-		computed.setFlags(flags & ^fPendingComputed)
-		return false
-	}() {
-		if updateComputed(rs, computed) {
-			subs := computed.subs()
+func processComputedUpdate(rs *ReactiveSystem, signal *signal, flags subscriberFlags) {
+	dirty := flags&fDirty != 0
+	if !dirty {
+		dirty = rs.checkDirty(signal.deps)
+		signal.flags = flags & ^fPendingComputed
+	}
+	if dirty {
+		if updateComputed(rs, signal) {
+			subs := signal.subs
 			if subs != nil {
 				rs.shallowPropagate(subs)
 			}

--- a/computed.go
+++ b/computed.go
@@ -71,17 +71,14 @@ func updateComputed(rs *ReactiveSystem, signal *signal) bool {
 // @param computed - The computed subscriber to update.
 // @param flags - The current flag set for this subscriber.
 func processComputedUpdate(rs *ReactiveSystem, signal *signal, flags subscriberFlags) {
-	dirty := flags&fDirty != 0
-	if !dirty {
-		dirty = rs.checkDirty(signal.deps)
-		signal.flags = flags & ^fPendingComputed
-	}
-	if dirty {
+	if flags&fDirty != 0 || rs.checkDirty(signal.deps) {
 		if updateComputed(rs, signal) {
 			subs := signal.subs
 			if subs != nil {
 				rs.shallowPropagate(subs)
 			}
 		}
+	} else {
+		signal.flags = flags & ^fPendingComputed
 	}
 }

--- a/reactive_systems.go
+++ b/reactive_systems.go
@@ -126,6 +126,7 @@ top:
 
 					return false
 				}
+				return true
 			}
 		} else if depFlags&(fComputed|fPendingComputed) == fComputed|fPendingComputed {
 			dep.flags = depFlags & ^fPendingComputed
@@ -275,7 +276,7 @@ top:
 			if subSubs != nil {
 				current = subSubs
 				if subSubs.nextSub != nil {
-					branchs = &OneWayLink_link{target: current, linked: branchs}
+					branchs = &OneWayLink_link{target: next, linked: branchs}
 					branchDepth++
 					next = current.nextSub
 					targetFlag = fPendingComputed

--- a/reactive_systems.go
+++ b/reactive_systems.go
@@ -4,17 +4,27 @@ type OnErrorFunc func(from SignalAware, err error)
 
 type ReactiveSystem struct {
 	batchDepth        int
-	activeSub         subscriber
-	queuedEffects     *EffectRunner
-	queuedEffectsTail *EffectRunner
+	activeSub         *signal
+	queuedEffects     *OneWayLink_signal
+	queuedEffectsTail *OneWayLink_signal
 
-	activeScope subscriber
+	activeScope *signal
 	onError     OnErrorFunc
-	pauseStack  []subscriber
+	pauseStack  []*signal
 }
 
 type SignalAware interface {
 	isSignalAware()
+}
+
+type OneWayLink_signal struct {
+	target *signal
+	linked *OneWayLink_signal
+}
+
+type OneWayLink_link struct {
+	target *link
+	linked *OneWayLink_link
 }
 
 func CreateReactiveSystem(onError OnErrorFunc) *ReactiveSystem {
@@ -59,12 +69,12 @@ func (rs *ReactiveSystem) ResumeTracking() {
 // @param sub - The subscriber to update.
 // @param flags - The current flag set for this subscriber.
 // @returns `true` if the subscriber is marked as Dirty; otherwise `false`.
-func (rs *ReactiveSystem) updateDirtyFlag(sub subscriber, flags subscriberFlags) bool {
-	if rs.checkDirty(sub.deps()) {
-		sub.setFlags(flags | fDirty)
+func (rs *ReactiveSystem) updateDirtyFlag(sub *signal, flags subscriberFlags) bool {
+	if rs.checkDirty(sub.deps) {
+		sub.flags = flags | fDirty
 		return true
 	}
-	sub.setFlags(flags & ^fPendingComputed)
+	sub.flags = flags & ^fPendingComputed
 	return false
 }
 
@@ -76,90 +86,60 @@ func (rs *ReactiveSystem) updateDirtyFlag(sub subscriber, flags subscriberFlags)
 //
 // @param link - The starting link representing a sequence of pending computeds.
 // @returns `true` if a computed was updated, otherwise `false`.
-func (rs *ReactiveSystem) checkDirty(link *link) (dirty bool) {
-	stack := 0
+func (rs *ReactiveSystem) checkDirty(current *link) bool {
+	prevLinks := (*OneWayLink_link)(nil)
+	checkDepth := 0
 
 top:
 	for {
-		dirty = false
-		dep := link.dep
-		dependencySubscriber, isDependencySubscriber := dep.(dependencyAndSubscriber)
-		if isDependencySubscriber {
-			depFlags := dependencySubscriber.flags()
-			if depFlags&(fComputed|fDirty) == fComputed|fDirty {
-				if updateComputed(rs, dep) {
-					subs := dep.subs()
-					if subs.nextSub != nil {
-						rs.shallowPropagate(subs)
-					}
-					dirty = true
+		dep := current.dep
+		depFlags := dep.flags
+		if depFlags&(fComputed|fDirty) == fComputed|fDirty {
+			if updateComputed(rs, dep) {
+				subs := dep.subs
+				if subs.nextSub != nil {
+					rs.shallowPropagate(subs)
 				}
-			} else if depFlags&(fComputed|fPendingComputed) == fComputed|fPendingComputed {
-				depSubs := dep.subs()
-				if depSubs.nextSub != nil {
-					depSubs.prevSub = link
-				}
-				link = dependencySubscriber.deps()
-				stack++
-				continue
-			}
-		}
+				for checkDepth != 0 {
+					checkDepth--
+					computed := current.sub
+					firstSub := computed.subs
 
-		if !dirty && link.nextDep != nil {
-			link = link.nextDep
-			continue
-		}
-
-		if stack != 0 {
-			s := link.sub
-			sub, ok := s.(dependencyAndSubscriber)
-			if !ok {
-				panic("not a dependencyAndSubscriber")
-			}
-			for {
-				if stack == 0 {
-					break
-				}
-
-				stack--
-				subSubs := sub.subs()
-
-				if dirty {
-					if updateComputed(rs, sub) {
-						link = subSubs.prevSub
-						if link != nil {
-							subSubs.prevSub = nil
-							rs.shallowPropagate(sub.subs())
-							sub = link.sub.(dependencyAndSubscriber)
+					if updateComputed(rs, current.sub) {
+						if firstSub.nextSub != nil {
+							rs.shallowPropagate(firstSub)
+							current = prevLinks.target
+							prevLinks = prevLinks.linked
 						} else {
-							sub = subSubs.sub.(dependencyAndSubscriber)
+							current = firstSub
 						}
 						continue
 					}
-				} else {
-					sub.setFlags(sub.flags() & ^fPendingComputed)
-				}
 
-				link = subSubs.prevSub
-				if link != nil {
-					subSubs.prevSub = nil
-					if link.nextDep != nil {
-						link = link.nextDep
+					if firstSub.nextSub != nil {
+						if current = prevLinks.target.nextDep; current == nil {
+							return false
+						}
+						prevLinks = prevLinks.linked
 						continue top
 					}
-					sub = link.sub.(dependencyAndSubscriber)
-				} else {
-					link = subSubs.nextDep
-					if link != nil {
-						continue top
-					}
-					sub = subSubs.sub.(dependencyAndSubscriber)
+
+					return false
 				}
-				dirty = false
 			}
+		} else if depFlags&(fComputed|fPendingComputed) == fComputed|fPendingComputed {
+			dep.flags = depFlags & ^fPendingComputed
+			if current.nextSub != nil && current.prevSub != nil {
+				prevLinks = &OneWayLink_link{target: current, linked: prevLinks}
+			}
+			checkDepth++
+			current = dep.deps
+			continue
 		}
 
-		return dirty
+		if current = current.nextDep; current == nil {
+			return false
+		}
 	}
 }
 
@@ -168,8 +148,8 @@ top:
 // @param dep - The dependency to be linked.
 // @param sub - The subscriber that depends on this dependency.
 // @returns The newly created link object if the two are not already linked; otherwise `undefined`.
-func (rs *ReactiveSystem) link(dep dependency, sub subscriber) *link {
-	currentDep := sub.depsTail()
+func (rs *ReactiveSystem) link(dep *signal, sub *signal) *link {
+	currentDep := sub.depsTail
 	if currentDep != nil && currentDep.dep == dep {
 		return nil
 	}
@@ -178,14 +158,14 @@ func (rs *ReactiveSystem) link(dep dependency, sub subscriber) *link {
 	if currentDep != nil {
 		nextDep = currentDep.nextDep
 	} else {
-		nextDep = sub.deps()
+		nextDep = sub.deps
 	}
 	if nextDep != nil && nextDep.dep == dep {
-		sub.setDepsTail(nextDep)
+		sub.depsTail = nextDep
 		return nil
 	}
 
-	depLastSub := dep.subsTail()
+	depLastSub := dep.subsTail
 	if depLastSub != nil && depLastSub.sub == sub && rs.isValidLink(depLastSub, sub) {
 		return nil
 	}
@@ -202,10 +182,10 @@ func (rs *ReactiveSystem) link(dep dependency, sub subscriber) *link {
 // @param checkLink - The link object to validate.
 // @param sub - The subscriber whose link list is being checked.
 // @returns `true` if the link is found in the subscriber's list; otherwise `false`.
-func (rs *ReactiveSystem) isValidLink(checkLink *link, sub subscriber) bool {
-	depsTails := sub.depsTail()
+func (rs *ReactiveSystem) isValidLink(checkLink *link, sub *signal) bool {
+	depsTails := sub.depsTail
 	if depsTails != nil {
-		link := sub.deps()
+		link := sub.deps
 		for {
 			if link == checkLink {
 				return true
@@ -233,7 +213,7 @@ func (rs *ReactiveSystem) isValidLink(checkLink *link, sub subscriber) bool {
 // @param nextDep - The next link in the subscriber's chain.
 // @param depsTail - The current tail link in the subscriber's chain.
 // @returns The newly created link object.
-func (rs *ReactiveSystem) linkNewDep(dep dependency, sub subscriber, nextDep, depsTail *link) *link {
+func (rs *ReactiveSystem) linkNewDep(dep *signal, sub *signal, nextDep, depsTail *link) *link {
 	newLink := &link{
 		dep:     dep,
 		sub:     sub,
@@ -241,21 +221,21 @@ func (rs *ReactiveSystem) linkNewDep(dep dependency, sub subscriber, nextDep, de
 	}
 
 	if depsTail == nil {
-		sub.setDeps(newLink)
+		sub.deps = newLink
 	} else {
 		depsTail.nextDep = newLink
 	}
 
-	if dep.subs() == nil {
-		dep.setSubs(newLink)
+	if dep.subs == nil {
+		dep.subs = newLink
 	} else {
-		oldTail := dep.subsTail()
+		oldTail := dep.subsTail
 		newLink.prevSub = oldTail
 		oldTail.nextSub = newLink
 	}
 
-	sub.setDepsTail(newLink)
-	dep.setSubsTail(newLink)
+	sub.depsTail = newLink
+	dep.subsTail = newLink
 
 	return newLink
 }
@@ -267,45 +247,40 @@ func (rs *ReactiveSystem) linkNewDep(dep dependency, sub subscriber, nextDep, de
 // This function should be called after a signal's value changes.
 //
 // @param link - The starting link from which propagation begins.
-func (rs *ReactiveSystem) propagate(link *link) {
+func (rs *ReactiveSystem) propagate(current *link) {
+	next := current.nextSub
+	branchs := (*OneWayLink_link)(nil)
+	branchDepth := 0
 	targetFlag := fDirty
-	subs := link
-	stack := 0
 
 top:
 	for {
-		sub := link.sub
-		subFlags := sub.flags()
+		sub := current.sub
+		flags := sub.flags
+		shouldNotify := false
 
-		if (subFlags&(fTracking|fRecursed|fPropagated) == 0 &&
-			func() bool {
-				sub.setFlags(subFlags | targetFlag | fNotified)
-				return true
-			}()) ||
-			(subFlags&fRecursed != 0 && subFlags&fTracking == 0 && func() bool {
-				sub.setFlags(subFlags&^fRecursed | targetFlag | fNotified)
-				return true
-			}()) ||
-			(subFlags&fPropagated == 0 && rs.isValidLink(link, sub) && func() bool {
-				sub.setFlags(subFlags | fRecursed | targetFlag | fNotified)
-				subDep, ok := sub.(dependencyAndSubscriber)
-				return ok && subDep.subs() != nil
-			}()) {
-			subDep, ok := sub.(dependencyAndSubscriber)
-			if !ok {
-				panic("not a dependencyAndSubscriber")
-			}
-			subSubs := subDep.subs()
+		if flags&(fTracking|fRecursed|fPropagated) == 0 {
+			sub.flags = flags | targetFlag | fNotified
+			shouldNotify = true
+		} else if flags&fRecursed != 0 && flags&fTracking == 0 {
+			sub.flags = flags&^fRecursed | targetFlag | fNotified
+			shouldNotify = true
+		} else if flags&fPropagated == 0 && rs.isValidLink(current, sub) {
+			sub.flags = flags | fRecursed | targetFlag | fNotified
+			shouldNotify = sub.subs != nil
+		}
+
+		if shouldNotify {
+			subSubs := sub.subs
 			if subSubs != nil {
+				current = subSubs
 				if subSubs.nextSub != nil {
-					subSubs.prevSub = subs
-					link = subSubs
-					subs = subSubs
+					branchs = &OneWayLink_link{target: current, linked: branchs}
+					branchDepth++
+					next = current.nextSub
 					targetFlag = fPendingComputed
-					stack++
 				} else {
-					link = subSubs
-					if subFlags&fEffect != 0 {
+					if flags&fEffect != 0 {
 						targetFlag = fPendingEffect
 					} else {
 						targetFlag = fPendingComputed
@@ -313,35 +288,35 @@ top:
 				}
 				continue
 			}
-			if subFlags&fEffect != 0 {
-				effect := mustEffect(sub)
+			if flags&fEffect != 0 {
 				if rs.queuedEffectsTail != nil {
-					rs.queuedEffectsTail.depsTail().nextDep = sub.deps()
+					rs.queuedEffectsTail.linked = &OneWayLink_signal{target: sub}
+					rs.queuedEffectsTail = rs.queuedEffectsTail.linked
 				} else {
-					rs.queuedEffects = effect
+					rs.queuedEffects = &OneWayLink_signal{target: sub}
+					rs.queuedEffectsTail = rs.queuedEffects
 				}
-				rs.queuedEffectsTail = effect
 			}
-		} else if subFlags&(fTracking|targetFlag) == 0 {
-			sub.setFlags(subFlags | targetFlag | fNotified)
-			if subFlags&(fEffect|fNotified) == fEffect {
-				effect := mustEffect(sub)
+		} else if flags&(fTracking|targetFlag) == 0 {
+			sub.flags = flags | targetFlag | fNotified
+			if flags&(fEffect|fNotified) == fEffect {
 				if rs.queuedEffectsTail != nil {
-					rs.queuedEffectsTail.depsTail().nextDep = sub.deps()
+					rs.queuedEffectsTail.linked = &OneWayLink_signal{target: sub}
+					rs.queuedEffectsTail = rs.queuedEffectsTail.linked
 				} else {
-					rs.queuedEffects = effect
+					rs.queuedEffects = &OneWayLink_signal{target: sub}
+					rs.queuedEffectsTail = rs.queuedEffects
 				}
-				rs.queuedEffectsTail = effect
 			}
-		} else if subFlags&targetFlag == 0 &&
-			subFlags&fPropagated != 0 &&
-			rs.isValidLink(link, sub) {
-			sub.setFlags(subFlags | targetFlag)
+		} else if flags&targetFlag == 0 &&
+			flags&fPropagated != 0 &&
+			rs.isValidLink(current, sub) {
+			sub.flags = flags | targetFlag
 		}
 
-		if link = subs.nextSub; link != nil {
-			subs = link
-			if stack != 0 {
+		if current = next; current != nil {
+			next = current.nextSub
+			if branchDepth != 0 {
 				targetFlag = fPendingComputed
 			} else {
 				targetFlag = fDirty
@@ -349,17 +324,13 @@ top:
 			continue
 		}
 
-		for stack != 0 {
-			stack--
-			dep := subs.dep
-			depSubs := dep.subs()
-			subs = depSubs.prevSub
-			depSubs.prevSub = nil
-
-			link = subs.nextSub
-			if link != nil {
-				subs = link
-				if stack != 0 {
+		for branchDepth != 0 {
+			branchDepth--
+			current = branchs.target
+			branchs = branchs.linked
+			if current != nil {
+				next = current.nextSub
+				if branchDepth != 0 {
 					targetFlag = fPendingComputed
 				} else {
 					targetFlag = fDirty
@@ -380,19 +351,18 @@ top:
 func (rs *ReactiveSystem) shallowPropagate(link *link) {
 	for {
 		sub := link.sub
-		subFlags := sub.flags()
+		subFlags := sub.flags
 		justPendingDirty := subFlags & (fPendingComputed | fDirty)
 		if justPendingDirty == fPendingComputed {
-			sub.setFlags(subFlags | fDirty | fNotified)
+			sub.flags = subFlags | fDirty | fNotified
 			if subFlags&(fEffect|fNotified) == fEffect {
-				effect := mustEffect(sub)
 				if rs.queuedEffectsTail != nil {
-					rs.queuedEffectsTail.depsTail().nextDep = sub.deps()
+					rs.queuedEffectsTail.linked = &OneWayLink_signal{target: sub}
+					rs.queuedEffectsTail = rs.queuedEffectsTail.linked
 				} else {
-					rs.queuedEffects = effect
+					rs.queuedEffects = &OneWayLink_signal{target: sub}
+					rs.queuedEffectsTail = rs.queuedEffects
 				}
-
-				rs.queuedEffectsTail = effect
 			}
 		}
 		link = link.nextSub
@@ -409,11 +379,11 @@ func (rs *ReactiveSystem) shallowPropagate(link *link) {
 // sets its flags to indicate it is now tracking dependency links.
 //
 // @param sub - The subscriber to start tracking.
-func (rs *ReactiveSystem) startTracking(sub subscriber) {
-	sub.setDepsTail(nil)
-	flags := sub.flags()
+func (rs *ReactiveSystem) startTracking(sub *signal) {
+	sub.depsTail = nil
+	flags := sub.flags
 	revised := flags & ^(fNotified|fRecursed|fPropagated) | fTracking
-	sub.setFlags(revised)
+	sub.flags = revised
 }
 
 // Concludes tracking of dependencies for the specified subscriber.
@@ -422,8 +392,8 @@ func (rs *ReactiveSystem) startTracking(sub subscriber) {
 // updates the subscriber's flags to indicate tracking is complete.
 //
 // @param sub - The subscriber whose tracking is ending.
-func (rs *ReactiveSystem) endTracking(sub subscriber) {
-	depsTail := sub.depsTail()
+func (rs *ReactiveSystem) endTracking(sub *signal) {
+	depsTail := sub.depsTail
 	if depsTail != nil {
 		nextDep := depsTail.nextDep
 		if nextDep != nil {
@@ -431,13 +401,13 @@ func (rs *ReactiveSystem) endTracking(sub subscriber) {
 			depsTail.nextDep = nil
 		}
 	} else {
-		deps := sub.deps()
+		deps := sub.deps
 		if deps != nil {
 			rs.clearTracking(deps)
 		}
-		sub.setDeps(nil)
+		sub.deps = nil
 	}
-	sub.setFlags(sub.flags() & ^fTracking)
+	sub.flags = sub.flags & ^fTracking
 }
 
 // Clears dependency-subscription relationships starting at the given link.
@@ -456,30 +426,29 @@ func (rs *ReactiveSystem) clearTracking(link *link) {
 		if nextSub != nil {
 			nextSub.prevSub = prevSub
 		} else {
-			dep.setSubsTail(prevSub)
+			dep.subsTail = prevSub
 		}
 
 		if prevSub != nil {
 			prevSub.nextSub = nextSub
 		} else {
-			dep.setSubs(nextSub)
+			dep.subs = nextSub
 		}
 
-		depSub, ok := dep.(dependencyAndSubscriber)
-		ss := dep.subs()
-		if ss == nil && ok {
-			depFlags := depSub.flags()
-			if depFlags&fDirty == 0 {
-				depSub.setFlags(depFlags | fDirty)
+		subs := dep.subs
+		flags := dep.flags
+		if subs == nil && flags != 0 {
+			if flags&fDirty == 0 {
+				dep.flags = flags | fDirty
 			}
 
-			depDeps := depSub.deps()
+			depDeps := dep.deps
 			if depDeps != nil {
 				link = depDeps
-				dt := depSub.depsTail()
+				dt := dep.depsTail
 				dt.nextDep = nextDep
-				depSub.setDeps(nil)
-				depSub.setDepsTail(nil)
+				dep.deps = nil
+				dep.depsTail = nil
 				continue
 			}
 		}

--- a/signals.go
+++ b/signals.go
@@ -1,7 +1,7 @@
 package alien
 
 type WriteableSignal[T comparable] struct {
-	baseDependency
+	signal
 	rs    *ReactiveSystem
 	value T
 }
@@ -10,7 +10,7 @@ func (s *WriteableSignal[T]) isSignalAware() {}
 
 func (s *WriteableSignal[T]) Value() T {
 	if s.rs.activeSub != nil {
-		s.rs.link(s, s.rs.activeSub)
+		s.rs.link(&s.signal, s.rs.activeSub)
 	}
 	return s.value
 }
@@ -20,7 +20,7 @@ func (s *WriteableSignal[T]) SetValue(v T) {
 		return
 	}
 	s.value = v
-	subs := s._subs
+	subs := s.signal.subs
 	if subs != nil {
 		s.rs.propagate(subs)
 		if s.rs.batchDepth == 0 {
@@ -31,8 +31,11 @@ func (s *WriteableSignal[T]) SetValue(v T) {
 
 func Signal[T comparable](rs *ReactiveSystem, initialValue T) *WriteableSignal[T] {
 	s := &WriteableSignal[T]{
-		rs:    rs,
-		value: initialValue,
+		rs:     rs,
+		value:  initialValue,
+		signal: signal{},
 	}
+	signal := &s.signal
+	signal.ref = s
 	return s
 }

--- a/types.go
+++ b/types.go
@@ -16,77 +16,15 @@ const (
 )
 
 type link struct {
-	dep dependency
-	sub subscriber
-	// reused to link the previous stack in updateDirtyFlags
-	// reused to link the previous stack in propagate
+	dep     *signal
+	sub     *signal
 	prevSub *link
 	nextSub *link
-	// reused to link the notify effect in queueEffects
 	nextDep *link
 }
 
-type subscriber interface {
-	flags() subscriberFlags
-	setFlags(subscriberFlags)
-	deps() *link
-	setDeps(*link)
-	depsTail() *link
-	setDepsTail(*link)
-}
-
-type baseSubscriber struct {
-	_flags           subscriberFlags
-	_deps, _depsTail *link
-}
-
-func (s *baseSubscriber) flags() subscriberFlags {
-	return s._flags
-}
-func (s *baseSubscriber) setFlags(flags subscriberFlags) {
-	s._flags = flags
-}
-func (s *baseSubscriber) deps() *link {
-	return s._deps
-}
-func (s *baseSubscriber) setDeps(deps *link) {
-	s._deps = deps
-}
-func (s *baseSubscriber) depsTail() *link {
-	return s._depsTail
-}
-func (s *baseSubscriber) setDepsTail(depsTail *link) {
-	s._depsTail = depsTail
-}
-
-type dependency interface {
-	subs() *link
-	setSubs(*link)
-	subsTail() *link
-	setSubsTail(*link)
-}
-
-type baseDependency struct {
-	_subs, _subsTail *link
-}
-
-func (d *baseDependency) subs() *link {
-	return d._subs
-}
-
-func (d *baseDependency) setSubs(subs *link) {
-	d._subs = subs
-}
-
-func (d *baseDependency) subsTail() *link {
-	return d._subsTail
-}
-
-func (d *baseDependency) setSubsTail(subsTail *link) {
-	d._subsTail = subsTail
-}
-
-type dependencyAndSubscriber interface {
-	dependency
-	subscriber
+type signal struct {
+	ref                            interface{}
+	flags                          subscriberFlags
+	deps, depsTail, subs, subsTail *link
 }


### PR DESCRIPTION
### Changes

- Synchronize algorithms with 1.0.7
- Merge baseDependency, baseSubscriber into single signal struct, this will avoid type conversion in reactive_systems.
- Use flags directly to determine the type of dep.
- Instead of using the interface as a reference to dep and sub, the interface is exposed via signal.ref.

### Benchmark

main branch

```
+------------------------+-------------+------------+-------------+-------------+-------------+
| BENCHMARK              |         AVG |        MIN |         P75 |         P99 |         MAX |
+------------------------+-------------+------------+-------------+-------------+-------------+
| propagate: 1 * 1       |       332ns |      125ns |       167ns |       334ns |    16.542µs |
| propagate: 1 * 10      |       952ns |      750ns |         1µs |     1.292µs |         2µs |
| propagate: 1 * 100     |     5.947µs |    5.833µs |     5.958µs |     6.417µs |      6.75µs |
| propagate: 1 * 1000    |    54.862µs |   53.042µs |    54.791µs |    59.083µs |    68.125µs |
| propagate: 10 * 1      |     1.213µs |    1.166µs |     1.209µs |     1.292µs |     1.708µs |
| propagate: 10 * 10     |     6.576µs |    6.416µs |     6.791µs |     7.208µs |     7.209µs |
| propagate: 10 * 100    |    60.499µs |       58µs |     59.75µs |    82.833µs |    83.208µs |
| propagate: 10 * 1000   |   551.053µs |  536.458µs |   550.084µs |   636.417µs |   638.375µs |
| propagate: 100 * 1     |     13.67µs |   11.667µs |    12.209µs |    51.083µs |   121.834µs |
| propagate: 100 * 10    |    72.248µs |   69.208µs |    72.584µs |    76.125µs |    92.458µs |
| propagate: 100 * 100   |   590.335µs |  581.667µs |   590.125µs |   618.125µs |   644.417µs |
| propagate: 100 * 1000  |   5.48764ms | 5.456917ms |  5.488709ms |   5.74375ms |  5.937416ms |
| propagate: 1000 * 1    |   117.818µs |  116.958µs |     117.5µs |   128.458µs |   134.583µs |
| propagate: 1000 * 10   |   701.335µs |  693.417µs |   703.208µs |   714.708µs |   802.542µs |
| propagate: 1000 * 100  |  6.001302ms | 5.936709ms |  5.986375ms |  6.330875ms |  7.378917ms |
| propagate: 1000 * 1000 | 56.932538ms | 56.52575ms | 56.950541ms | 58.889416ms | 59.726667ms |
+------------------------+-------------+------------+-------------+-------------+-------------+
```

This PR

```
+------------------------+-------------+-------------+-------------+-------------+-------------+
| BENCHMARK              |         AVG |         MIN |         P75 |         P99 |         MAX |
+------------------------+-------------+-------------+-------------+-------------+-------------+
| propagate: 1 * 1       |       361ns |       125ns |       167ns |       708ns |    19.542µs |
| propagate: 1 * 10      |       560ns |       458ns |       625ns |     1.083µs |     1.084µs |
| propagate: 1 * 100     |     4.122µs |     3.875µs |     3.959µs |     4.792µs |    20.542µs |
| propagate: 1 * 1000    |     46.66µs |    37.291µs |    56.584µs |     59.25µs |    83.583µs |
| propagate: 10 * 1      |     1.013µs |       916ns |         1µs |     1.583µs |     2.209µs |
| propagate: 10 * 10     |     4.303µs |     4.167µs |     4.333µs |     4.792µs |     4.834µs |
| propagate: 10 * 100    |    49.144µs |    39.917µs |    50.375µs |    54.083µs |   169.792µs |
| propagate: 10 * 1000   |   292.419µs |   269.459µs |   311.667µs |   383.917µs |   901.709µs |
| propagate: 100 * 1     |     5.846µs |     5.417µs |     5.708µs |    11.291µs |    11.959µs |
| propagate: 100 * 10    |    34.407µs |    32.458µs |    34.584µs |    41.459µs |    58.708µs |
| propagate: 100 * 100   |   300.712µs |   296.542µs |   301.417µs |   313.459µs |   330.083µs |
| propagate: 100 * 1000  |  2.803827ms |  2.755417ms |   2.79875ms |  3.175875ms |   3.21925ms |
| propagate: 1000 * 1    |    65.128µs |     58.25µs |    62.166µs |    88.292µs |   439.625µs |
| propagate: 1000 * 10   |   339.583µs |   324.459µs |     333.5µs |   398.083µs |  1.011583ms |
| propagate: 1000 * 100  |  3.141568ms |  3.085792ms |  3.134625ms |  3.653125ms |  3.900417ms |
| propagate: 1000 * 1000 | 30.555207ms | 30.248041ms | 30.541458ms | 32.487333ms | 32.699667ms |
+------------------------+-------------+-------------+-------------+-------------+-------------+
```